### PR TITLE
Compatiblity with ElasticSearch v1.5.2, Timestamp return format as milliseconds since 1970

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>2.0.1</version>
+      <version>${cassandra.version}</version>
     </dependency>
     <dependency>
       <groupId>org.xerial.snappy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <elasticsearch.version>1.5.2</elasticsearch.version>
-    <cassandra.version>2.0.6</cassandra.version>
+    <cassandra.version>2.1.5</cassandra.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <elasticsearch.version>1.2.1</elasticsearch.version>
+    <elasticsearch.version>1.5.2</elasticsearch.version>
     <cassandra.version>2.0.6</cassandra.version>
   </properties>
 

--- a/src/main/java/com/blu/es/cassandra/CassandraFactory.java
+++ b/src/main/java/com/blu/es/cassandra/CassandraFactory.java
@@ -4,8 +4,6 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +148,7 @@ public class CassandraFactory {
             }
             case TIMESTAMP: {
                 Date raw = row.getDate(columnName);
-                value = raw != null ? raw.toString() : "";
+                value = raw != null ? String.valueOf(raw.getTime()) : "";
                 break;
             }
             case TIMEUUID:


### PR DESCRIPTION
Hi:

Using ElasticSearch v1.5.2 an exception is throwed everytime because there's no ListenableActionFuture.addListener(Runnable), but :

Exception in thread "Queue-Indexer-thread-0" java.lang.NoSuchMethodError: org.elasticsearch.action.ListenableActionFuture.addListener(Ljava/lang/Runnable;)V
    at com.blu.es.cassandra.CassandraRiver$Indexer.saveToEs(CassandraRiver.java:353)
    at com.blu.es.cassandra.CassandraRiver$Indexer.run(CassandraRiver.java:347)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)

I've also changed the way a timestamp is returned because there is a problem in elasticsearch when trying to parse a Date containing timezones like CEST.  Now, a date is returned as a timestamp (milliseconds since 1970).

Kind regards,
